### PR TITLE
Caching of outputs

### DIFF
--- a/src/it/scala/net/santiment/BitcoinClientSpec.scala
+++ b/src/it/scala/net/santiment/BitcoinClientSpec.scala
@@ -12,7 +12,7 @@ import org.bitcoinj.script.{Script, ScriptBuilder}
 class BitcoinClientSpec extends FunSuite with LazyLogging {
 
   test("getBlockHash should work") {
-    val hash = bitcoin.getBlockHash(500000)
+    val hash = bitcoinClient.getBlockHash(500000)
     assert(hash == Sha256Hash.wrap("00000000000000000024fb37364cbf81fd49cc2d51c09c75c35433c3a1945d04"))
   }
 
@@ -22,7 +22,7 @@ class BitcoinClientSpec extends FunSuite with LazyLogging {
   }
 
   test("getTx should work") {
-    val tx = bitcoin.getTx(Sha256Hash.wrap("2157b554dcfda405233906e461ee593875ae4b1b97615872db6a25130ecc1dd6"))
+    val tx = bitcoinClient.getTx(Sha256Hash.wrap("2157b554dcfda405233906e461ee593875ae4b1b97615872db6a25130ecc1dd6"))
     assert(tx.getInput(0).getSequenceNumber == 4294967295L)
   }
 
@@ -33,7 +33,7 @@ class BitcoinClientSpec extends FunSuite with LazyLogging {
   test("getTxList should work") {
     val tx1 = Sha256Hash.wrap("2157b554dcfda405233906e461ee593875ae4b1b97615872db6a25130ecc1dd6")
     val tx2 = Sha256Hash.wrap("0aa3d7cbbd35484632645675f5a6f28440a604975ce254c5701e4602f7d8dcc6")
-    val result = bitcoin.getTxList(Set(tx1,tx2))
+    val result = bitcoinClient.getTxList(Set(tx1,tx2))
     assert(result(tx1).getInput(0).getSequenceNumber == 4294967295L)
     assert(result(tx2).getInput(0).getSequenceNumber == 4294967294L)
   }

--- a/src/main/scala/net/santiment/BlockStore.scala
+++ b/src/main/scala/net/santiment/BlockStore.scala
@@ -1,0 +1,123 @@
+package net.santiment
+
+import java.{lang, util}
+
+import com.google.common.cache.{CacheBuilder, CacheLoader, CacheStats, LoadingCache}
+import com.typesafe.scalalogging.LazyLogging
+import org.bitcoinj.core._
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+/**
+  * A class for retrieving and caching tx outputs
+  *
+  * @param client - Bitcoin client used for getting data
+  */
+
+class BlockStore(client:BitcoinClient) extends LazyLogging with Periodic[CacheStats] {
+
+  override val period: Int = 60000
+
+  case class OutputKey(hash:Sha256Hash, index:Long)
+
+  object OutputKey {
+    def fromOutpoint(o:TransactionOutPoint):OutputKey = OutputKey(o.getHash,o.getIndex)
+  }
+
+  // Cache for storing tx outputs
+  val outputCache:LoadingCache[OutputKey,TransactionOutput] = CacheBuilder.newBuilder()
+    .maximumSize(10000)
+    .initialCapacity(10000)
+    .recordStats()
+    .build(new CacheLoader[OutputKey, TransactionOutput] {
+      override def load(key: OutputKey): TransactionOutput = {
+        val tx = client.getTx(key.hash)
+        val output = tx.getOutput(key.index)
+        //Remove connection with parent tx to allow for gc
+        output.setParent(null)
+        output
+      }
+
+      override def loadAll(keys: lang.Iterable[_ <: OutputKey]): util.Map[OutputKey, TransactionOutput] = {
+        val inputHashes = mutable.HashSet[Sha256Hash]()
+
+        for( key<- keys.asScala ) {
+          inputHashes.add(key.hash)
+        }
+
+        //Get all parent transactions
+        val parents:collection.Map[Sha256Hash,Transaction] = client.getTxList(inputHashes)
+        val result = new util.HashMap[OutputKey,TransactionOutput]()
+        for (key <- keys.asScala) {
+          val output = parents(key.hash).getOutput(key.index)
+          output.setParent(null)
+          result.put(key,output)
+        }
+
+        result
+      }
+    })
+
+
+  def getBlock(height:Integer): Block = {
+    val block = client.getBlock(height)
+
+    // We will disconnect here all inputs and outputs from their parent transactions.
+    // This will allow the garbage collector to clean the tx objects even if we are
+    // storing the inputs or outputs
+
+    for (tx<- block.getTransactions.asScala) {
+      val hash = tx.getHash
+
+      for (in <- tx.getInputs.asScala) {
+        in.setParent(null)
+      }
+
+      for(out <- tx.getOutputs.asScala) {
+        //Cache the output then remove connection with parent
+        outputCache.put(OutputKey(hash,out.getIndex),out)
+        out.setParent(null)
+      }
+    }
+
+    //Print cache stats
+    occasionally( (oldStats:CacheStats)=> {
+      val stats = outputCache.stats()
+      val diff = if(oldStats != null) {stats.minus(oldStats)} else stats
+      logger.info(s"Cache stats: $diff")
+      stats
+    })
+
+    block
+  }
+
+  /**
+    * Get and cache all outputs connected to the inputs in the given transactions
+    * @param txs
+    */
+  def cacheOutputs(txs: lang.Iterable[_ <: Transaction]): Unit = {
+    val keys = for (
+      tx <- txs.asScala;
+      input <- tx.getInputs.asScala
+    ) yield {
+      OutputKey.fromOutpoint(input.getOutpoint)
+    }
+
+    if (keys.nonEmpty) {
+      logger.debug(s"getAll: $keys")
+      outputCache.getAll(keys.asJava)
+    }
+  }
+
+  def getOutput(input:TransactionInput):TransactionOutput = {
+    val key = OutputKey.fromOutpoint(input.getOutpoint)
+    logger.debug(s"get: $key")
+    val output = outputCache.get(key)
+    outputCache.invalidate(key)
+    output
+  }
+
+  def blockCount:Int = client.blockCount
+
+}

--- a/src/main/scala/net/santiment/Globals.scala
+++ b/src/main/scala/net/santiment/Globals.scala
@@ -82,7 +82,8 @@ class Globals extends LazyLogging
 
   lazy val bitcoindJsonRpcClient: JsonRpcHttpClient = makeBitcoindJsonRpcClient(config.bitcoind)
 
-  lazy val bitcoin:BitcoinClient = new BitcoinClient(bitcoindJsonRpcClient)
+  lazy val bitcoinClient:BitcoinClient = new BitcoinClient(bitcoindJsonRpcClient)
+  lazy val bitcoin = new BlockStore(bitcoinClient)
 
   def makeBitcoindJsonRpcClient(config:BitcoinClientConfig): JsonRpcHttpClient = {
 

--- a/src/main/scala/net/santiment/Periodic.scala
+++ b/src/main/scala/net/santiment/Periodic.scala
@@ -1,14 +1,15 @@
 package net.santiment
 
-trait Periodic {
+trait Periodic[State] {
   val period: Int = 10000
 
+  var state:State = _
   private var startTs = System.currentTimeMillis()
 
-  def occasionally(f: => Unit):Unit = {
+  def occasionally(f: State => State):Unit = {
     var test = System.currentTimeMillis()
     if (test - startTs >= period) {
-      f
+      state = f(state)
       startTs = test
 
     }


### PR DESCRIPTION
We cache the outputs in a way which reduces the memory consumption (in
comparison to caching transactions)