### PR TITLE
Optimize code

### DIFF
--- a/src/main/scala/net/santiment/BitcoinKafkaProducer.scala
+++ b/src/main/scala/net/santiment/BitcoinKafkaProducer.scala
@@ -137,8 +137,8 @@ class BitcoinKafkaProducer
       val credits = for(input:TransactionInput <- tx.getInputs.asScala) yield {
         val output = world.bitcoin.getOutput(input)
 
-        val account = BitcoinClient.extractAddress(output.getScriptPubKey)
-        val value: Coin = output.getValue
+        val account = BitcoinClient.extractAddress(output.script)
+        val value: Coin = output.value
 
 
         //We store credits as negative values


### PR DESCRIPTION
Reduced the size of a single cached output by about 1/2. This should allow us to store twice as many cached outputs for the same amount of memory.